### PR TITLE
🎨 Palette: Add search filter to resources page

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - Static Site Search Patterns
 **Learning:** Static sites with client-side filtering often miss "empty states" (no results found), leaving users confused when a search yields nothing. They also frequently lack proper form labels.
 **Action:** Always check for and implement "No results" feedback and explicit labels (visible or sr-only) when enhancing static list filters.
+
+## 2024-05-24 - Filtered List Category Management
+**Learning:** When filtering categorized lists (like resources or tools), keeping empty category headers visible creates visual noise and requires unnecessary scrolling.
+**Action:** Implement logic to hide parent containers/headers when all their child items are filtered out.

--- a/resources.html
+++ b/resources.html
@@ -50,6 +50,18 @@
 
   <main>
 
+    <div class="search-container">
+        <div class="search-wrapper">
+            <label for="resourceSearch" class="sr-only">Search Resources</label>
+            <input type="text" id="resourceSearch" class="search-input" placeholder="Search resources (e.g., 'shodan', 'threat', 'learning')..." aria-label="Search Resources">
+            <button id="clearSearch" class="clear-button hidden" aria-label="Clear search" type="button">✕</button>
+        </div>
+    </div>
+
+    <div id="noResults" class="no-results hidden">
+        <p>No resources found matching your criteria. Try different keywords.</p>
+    </div>
+
     <div class="resource-category">
         <h2 class="wiki-section-title">🔍 Search Engines & Recon</h2>
         <div class="resource-list">
@@ -345,5 +357,65 @@
   <footer>
     <p>&copy; Zero Trust. Hosted with ❤️ on GitHub Pages.</p>
   </footer>
+
+  <script>
+    const searchInput = document.getElementById('resourceSearch');
+    const clearBtn = document.getElementById('clearSearch');
+    const noResults = document.getElementById('noResults');
+    const categories = document.querySelectorAll('.resource-category');
+
+    function filterResources(searchTerm) {
+        searchTerm = searchTerm.toLowerCase();
+        let totalVisible = 0;
+
+        categories.forEach(category => {
+            let categoryVisibleCount = 0;
+            const items = category.querySelectorAll('.resource-item');
+
+            items.forEach(item => {
+                const title = item.querySelector('.resource-title').textContent.toLowerCase();
+                const domain = item.querySelector('.resource-domain').textContent.toLowerCase();
+
+                if (title.includes(searchTerm) || domain.includes(searchTerm)) {
+                    item.classList.remove('hidden');
+                    categoryVisibleCount++;
+                } else {
+                    item.classList.add('hidden');
+                }
+            });
+
+            if (categoryVisibleCount > 0) {
+                category.classList.remove('hidden');
+                totalVisible += categoryVisibleCount;
+            } else {
+                category.classList.add('hidden');
+            }
+        });
+
+        // Toggle No Results
+        if (totalVisible === 0) {
+            noResults.classList.remove('hidden');
+        } else {
+            noResults.classList.add('hidden');
+        }
+
+        // Toggle Clear Button
+        if (searchTerm) {
+            clearBtn.classList.remove('hidden');
+        } else {
+            clearBtn.classList.add('hidden');
+        }
+    }
+
+    searchInput.addEventListener('input', (e) => {
+        filterResources(e.target.value);
+    });
+
+    clearBtn.addEventListener('click', () => {
+        searchInput.value = '';
+        filterResources('');
+        searchInput.focus();
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
Added a client-side search filter to the resources page.

💡 What:
- Added a search input with clear button to `resources.html`.
- Implemented real-time filtering logic that searches resource titles and domains.
- Automatically hides empty categories when all their items are filtered out.
- Displays a "No results" message when no matches are found.

🎯 Why:
- Improves discoverability of specific resources in the long list.
- Consistent UX with the `tools.html` page.

♿ Accessibility:
- Used `.sr-only` label for the search input.
- Added `aria-label` to the clear button.
- Ensured keyboard focus management when clearing the search.

---
*PR created automatically by Jules for task [11198121754816716723](https://jules.google.com/task/11198121754816716723) started by @PietjePuh*