### PR TITLE
Add instant search to Resources page

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - Static Site Search Patterns
 **Learning:** Static sites with client-side filtering often miss "empty states" (no results found), leaving users confused when a search yields nothing. They also frequently lack proper form labels.
 **Action:** Always check for and implement "No results" feedback and explicit labels (visible or sr-only) when enhancing static list filters.
+
+## 2024-05-24 - Dynamic Category Management in Search
+**Learning:** When filtering categorized lists (like on `resources.html`), hiding items without hiding their parent category headers leaves "ghost" headers that clutter the UI.
+**Action:** Always implement logic to check if a category is empty after filtering and hide the category header accordingly.

--- a/resources.html
+++ b/resources.html
@@ -49,6 +49,16 @@
   </header>
 
   <main>
+    <div class="search-container">
+        <div class="search-wrapper">
+            <label for="resourceSearch" class="sr-only">Search Resources</label>
+            <input type="text" id="resourceSearch" class="search-input" placeholder="Search resources (e.g., 'shodan', 'threat', 'learning')..." aria-label="Search Resources">
+            <button id="clearSearch" class="clear-button hidden" aria-label="Clear search" type="button">✕</button>
+        </div>
+    </div>
+    <div id="noResults" class="no-results hidden">
+        <p>No resources found matching your criteria.</p>
+    </div>
 
     <div class="resource-category">
         <h2 class="wiki-section-title">🔍 Search Engines & Recon</h2>
@@ -345,5 +355,72 @@
   <footer>
     <p>&copy; Zero Trust. Hosted with ❤️ on GitHub Pages.</p>
   </footer>
+  <script>
+    const searchInput = document.getElementById('resourceSearch');
+    const clearBtn = document.getElementById('clearSearch');
+    const noResults = document.getElementById('noResults');
+    const resourceCategories = document.querySelectorAll('.resource-category');
+    const resourceItems = document.querySelectorAll('.resource-item');
+
+    function filterResources(searchTerm) {
+        searchTerm = searchTerm.toLowerCase();
+        let totalVisible = 0;
+
+        // Filter individual items
+        resourceItems.forEach(item => {
+            const title = item.querySelector('.resource-title').textContent.toLowerCase();
+            const domain = item.querySelector('.resource-domain').textContent.toLowerCase();
+
+            if (title.includes(searchTerm) || domain.includes(searchTerm)) {
+                item.classList.remove('hidden');
+                totalVisible++;
+            } else {
+                item.classList.add('hidden');
+            }
+        });
+
+        // Handle Empty Categories
+        resourceCategories.forEach(category => {
+            const visibleItems = category.querySelectorAll('.resource-item:not(.hidden)');
+            if (visibleItems.length === 0) {
+                category.classList.add('hidden');
+            } else {
+                category.classList.remove('hidden');
+            }
+        });
+
+        // Toggle No Results
+        if (totalVisible > 0) {
+            noResults.classList.add('hidden');
+        } else {
+            noResults.classList.remove('hidden');
+        }
+
+        // Toggle Clear Button
+        if (searchTerm) {
+            clearBtn.classList.remove('hidden');
+        } else {
+            clearBtn.classList.add('hidden');
+        }
+    }
+
+    searchInput.addEventListener('input', (e) => {
+        filterResources(e.target.value);
+    });
+
+    clearBtn.addEventListener('click', () => {
+        searchInput.value = '';
+        filterResources('');
+        searchInput.focus();
+    });
+
+    // Check for query parameter
+    const urlParams = new URLSearchParams(window.location.search);
+    const query = urlParams.get('q');
+    if (query) {
+        searchInput.value = query;
+        filterResources(query);
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
🎨 **Palette: Instant Search for Resources**

I've added a client-side search feature to the `resources.html` page to make finding specific tools and links much faster.

**Why:**
Previously, users had to scroll through a long list of categorized links to find what they needed. Now they can instantly filter by name or domain (e.g., "shodan", "threat").

**What Changed:**
- Added a search bar at the top of the Resources list.
- Implemented vanilla JS filtering that hides non-matching items.
- Added logic to hide category headers if all their items are hidden.
- Added a "No results found" state for better feedback.
- Used existing CSS classes for consistent styling.

**Accessibility:**
- Added `aria-label` and `sr-only` label for the search input.
- Ensure the "Clear" button is keyboard accessible.

**Verification:**
- Verified filtering works correctly (e.g., searching "shodan" shows only Shodan).
- Verified empty categories are hidden.
- Verified "No results" message appears correctly.

---
*PR created automatically by Jules for task [8841358189713776998](https://jules.google.com/task/8841358189713776998) started by @PietjePuh*