### PR TITLE
🎨 Palette: Add keyboard shortcut to resources search

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2026-02-14 - Retrofitting Copy Interactions
 **Learning:** Static documentation often contains command snippets that users manually select and copy. Adding a dedicated 'Copy' button significantly reduces friction for technical users.
 **Action:** Identify repetitive patterns in documentation (like code blocks) and enhance them with client-side DOM manipulation to add utility controls.
+
+## 2024-05-24 - Global Keyboard Shortcuts Safety
+**Learning:** When implementing global hotkeys (like '/' for search), naive implementations can break typing in other input fields if they don't explicitly check document.activeElement.tagName.
+**Action:** Always wrap global keydown listeners with a check: if (activeTag !== 'INPUT' && activeTag !== 'TEXTAREA').

--- a/resources.html
+++ b/resources.html
@@ -57,7 +57,7 @@
     <div class="search-container">
         <div class="search-wrapper">
             <label for="resourceSearch" class="sr-only">Search Resources</label>
-            <input type="text" id="resourceSearch" class="search-input" placeholder="Search resources (e.g., 'shodan', 'threat', 'learning')..." aria-label="Search Resources">
+            <input type="text" id="resourceSearch" class="search-input" placeholder="Search resources (e.g., 'shodan', 'threat', 'learning')... (Press '/')" aria-label="Search Resources">
             <button id="clearSearch" class="clear-button hidden" aria-label="Clear search" type="button">✕</button>
         </div>
     </div>
@@ -427,6 +427,15 @@
         searchInput.value = query;
         filterResources(query);
     }
+
+    // Keyboard shortcut for search
+    document.addEventListener('keydown', (e) => {
+        const activeTag = document.activeElement.tagName;
+        if (e.key === '/' && activeTag !== 'INPUT' && activeTag !== 'TEXTAREA') {
+            e.preventDefault();
+            searchInput.focus();
+        }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
This change adds the `/` keyboard shortcut to `resources.html`, matching the functionality in `tools.html`. This improves accessibility and discoverability for power users. The implementation includes a check to ensure the shortcut doesn't interfere with typing in other input fields.

Verified with Playwright script (deleted) and manual screenshot inspection.

---
*PR created automatically by Jules for task [4775263885535432158](https://jules.google.com/task/4775263885535432158) started by @PietjePuh*