### PR TITLE
🎨 Palette: Add Back-to-Top Button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-05-24 - Global Keyboard Shortcuts Safety
 **Learning:** When implementing global hotkeys (like '/' for search), naive implementations can break typing in other input fields if they don't explicitly check document.activeElement.tagName.
 **Action:** Always wrap global keydown listeners with a check: if (activeTag !== 'INPUT' && activeTag !== 'TEXTAREA').
+
+## 2026-02-18 - Navigation on Long Static Pages
+**Learning:** On long static pages (like tools lists), users lose context of navigation. A simple, persistent 'Back to Top' button restores this context and is a high-value micro-UX improvement.
+**Action:** When designing or enhancing long content pages, always include a mechanism to quickly return to the top navigation.

--- a/css/style.css
+++ b/css/style.css
@@ -874,3 +874,48 @@ fieldset.filter-chips {
         page-break-after: avoid;
     }
 }
+
+/* Back to Top Button */
+.back-to-top {
+    position: fixed;
+    bottom: 2rem;
+    right: 2rem;
+    background-color: var(--accent-color);
+    color: var(--bg-color);
+    border: none;
+    border-radius: 50%;
+    width: 3rem;
+    height: 3rem;
+    font-size: 1.5rem;
+    cursor: pointer;
+    box-shadow: 0 4px 12px var(--shadow-color);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s, transform 0.2s;
+    z-index: 900;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.back-to-top.visible {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.back-to-top:hover,
+.back-to-top:focus {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 16px var(--shadow-color);
+    outline: none;
+}
+
+[data-theme="light"] .back-to-top {
+    color: #ffffff;
+}
+
+@media print {
+    .back-to-top {
+        display: none !important;
+    }
+}

--- a/js/theme.js
+++ b/js/theme.js
@@ -41,3 +41,42 @@
         });
     });
 })();
+
+// Back to Top Button Logic
+document.addEventListener('DOMContentLoaded', function () {
+    var backToTopBtn = document.createElement('button');
+    backToTopBtn.className = 'back-to-top';
+    backToTopBtn.ariaLabel = 'Back to top';
+    backToTopBtn.innerHTML = '&#8679;'; // Up arrow
+    backToTopBtn.type = 'button';
+
+    document.body.appendChild(backToTopBtn);
+
+    var toggleVisibility = function () {
+        if (window.scrollY > 300) {
+            backToTopBtn.classList.add('visible');
+        } else {
+            backToTopBtn.classList.remove('visible');
+        }
+    };
+
+    var ticking = false;
+    window.addEventListener('scroll', function () {
+        if (!ticking) {
+            window.requestAnimationFrame(function () {
+                toggleVisibility();
+                ticking = false;
+            });
+            ticking = true;
+        }
+    });
+
+    backToTopBtn.addEventListener('click', function () {
+        window.scrollTo({
+            top: 0,
+            behavior: 'smooth'
+        });
+        // Remove focus from button after click to avoid lingering focus style
+        backToTopBtn.blur();
+    });
+});


### PR DESCRIPTION
Added a responsive "Back to Top" button that appears on scroll for long pages like Tools and Resources. Implemented in vanilla JS/CSS for performance and accessibility.

Changes:
- Added `.back-to-top` styles to `css/style.css`
- Added logic to `js/theme.js` to create and toggle the button
- Verified with Playwright screenshot
- Added journal entry to `.Jules/palette.md`

---
*PR created automatically by Jules for task [2099430792034464151](https://jules.google.com/task/2099430792034464151) started by @PietjePuh*