### PR TITLE
🎨 Palette: Deep linking for resource filters

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2026-02-14 - Invisible Navigation Aids
 **Learning:** Users on long content pages often struggle to return to the top navigation without excessive scrolling, causing friction.
 **Action:** Implement unobtrusive "Back to Top" buttons that only appear after scrolling, maintaining a clean UI until the functionality is needed.
+
+## 2026-02-14 - Client-Side State Persistence
+**Learning:** Static site filters often reset on refresh, causing frustration when sharing links. Syncing filter state with URL parameters via `window.history.replaceState` creates persistent, shareable views without backend logic.
+**Action:** Always implement deep linking for client-side filters (search/categories) to enable bookmarking and sharing of specific resource views.

--- a/resources.html
+++ b/resources.html
@@ -383,7 +383,24 @@
     const filterChips = document.querySelectorAll('.filter-chip');
     let currentCat = 'all';
 
+    function updateURL() {
+        const url = new URL(window.location);
+        if (currentCat && currentCat !== 'all') {
+            url.searchParams.set('category', currentCat);
+        } else {
+            url.searchParams.delete('category');
+        }
+
+        if (searchInput.value) {
+            url.searchParams.set('q', searchInput.value);
+        } else {
+            url.searchParams.delete('q');
+        }
+        window.history.replaceState({}, '', url);
+    }
+
     function applyFilters() {
+        updateURL();
         var searchTerm = searchInput.value.toLowerCase();
         var totalVisible = 0;
 
@@ -470,8 +487,22 @@
     // Check for query parameter
     var urlParams = new URLSearchParams(window.location.search);
     var query = urlParams.get('q');
+    var categoryParam = urlParams.get('category');
+
+    if (categoryParam) {
+        var targetChip = document.querySelector('.filter-chip[data-cat="' + categoryParam + '"]');
+        if (targetChip) {
+            filterChips.forEach(function (c) { c.classList.remove('active'); });
+            targetChip.classList.add('active');
+            currentCat = categoryParam;
+        }
+    }
+
     if (query) {
         searchInput.value = query;
+    }
+
+    if (query || categoryParam) {
         applyFilters();
     }
 


### PR DESCRIPTION
Implemented deep linking for the Resources page. This allows users to bookmark or share specific filtered views (e.g., `?category=threat&q=virus`) by synchronizing the URL query parameters with the client-side filter state. This micro-UX improvement enhances the shareability and usability of the resource directory without requiring backend changes. Verified with Playwright tests.

---
*PR created automatically by Jules for task [4936295421111046478](https://jules.google.com/task/4936295421111046478) started by @PietjePuh*