### PR TITLE
feat: sync resource filters with URL

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2026-02-14 - Invisible Navigation Aids
 **Learning:** Users on long content pages often struggle to return to the top navigation without excessive scrolling, causing friction.
 **Action:** Implement unobtrusive "Back to Top" buttons that only appear after scrolling, maintaining a clean UI until the functionality is needed.
+
+## 2026-02-14 - Deep Linking in Static Sites
+**Learning:** Static site filters (like categories/search) often lack state persistence, causing users to lose context on refresh or share. Using `history.replaceState` is a clean, low-overhead way to add deep linking without a router.
+**Action:** Always implement URL synchronization for any client-side filtering or search mechanism to enable bookmarking and sharing.

--- a/resources.html
+++ b/resources.html
@@ -383,7 +383,24 @@
     const filterChips = document.querySelectorAll('.filter-chip');
     let currentCat = 'all';
 
+    function updateURL() {
+        const url = new URL(window.location);
+        if (currentCat && currentCat !== 'all') {
+            url.searchParams.set('category', currentCat);
+        } else {
+            url.searchParams.delete('category');
+        }
+
+        if (searchInput.value) {
+            url.searchParams.set('q', searchInput.value);
+        } else {
+            url.searchParams.delete('q');
+        }
+        window.history.replaceState({}, '', url);
+    }
+
     function applyFilters() {
+        updateURL();
         var searchTerm = searchInput.value.toLowerCase();
         var totalVisible = 0;
 
@@ -470,8 +487,24 @@
     // Check for query parameter
     var urlParams = new URLSearchParams(window.location.search);
     var query = urlParams.get('q');
+    var categoryParam = urlParams.get('category');
+
+    if (categoryParam) {
+        currentCat = categoryParam;
+        filterChips.forEach(function (chip) {
+            if (chip.getAttribute('data-cat') === currentCat) {
+                chip.classList.add('active');
+            } else {
+                chip.classList.remove('active');
+            }
+        });
+    }
+
     if (query) {
         searchInput.value = query;
+    }
+
+    if (query || categoryParam) {
         applyFilters();
     }
 


### PR DESCRIPTION
Implemented URL synchronization for the Resources page. This allows users to bookmark or share specific searches and category filters.

**Changes:**
- Modified `resources.html` to update the URL when filters change.
- Added logic to restore filters from the URL on page load.

**Verification:**
- Verified manually with Playwright script (screenshot confirmed correct state).
- Verified that refreshing the page preserves the selected category and search term.

---
*PR created automatically by Jules for task [3958113389595447418](https://jules.google.com/task/3958113389595447418) started by @PietjePuh*