### PR TITLE
feat(ux): sync resource filters to URL

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-02-14 - Styling Consistency in Mixed Static Sites
 **Learning:** Static sites may mix inline styles (for performance on landing pages like `index.html`) with external stylesheets (for other content pages). When adding global UI components, verify both contexts to avoid unstyled content.
 **Action:** Ensure global styles are either duplicated in the inline block or the external sheet is universally linked, testing both scenarios.
+
+## 2026-02-25 - URL State Synchronization in Static Sites
+**Learning:** Users expect to be able to share or bookmark their search/filter results, even on static sites. Implementing `history.replaceState` with `URLSearchParams` provides a seamless "app-like" experience without server-side routing.
+**Action:** Always sync client-side filter states (search, categories) to the URL query parameters to enable deep linking.

--- a/resources.html
+++ b/resources.html
@@ -383,7 +383,24 @@
     const filterChips = document.querySelectorAll('.filter-chip');
     let currentCat = 'all';
 
+    function updateURL() {
+        const url = new URL(window.location);
+        if (currentCat && currentCat !== 'all') {
+            url.searchParams.set('category', currentCat);
+        } else {
+            url.searchParams.delete('category');
+        }
+
+        if (searchInput.value) {
+            url.searchParams.set('q', searchInput.value);
+        } else {
+            url.searchParams.delete('q');
+        }
+        window.history.replaceState({}, '', url);
+    }
+
     function applyFilters() {
+        updateURL();
         var searchTerm = searchInput.value.toLowerCase();
         var totalVisible = 0;
 
@@ -470,8 +487,25 @@
     // Check for query parameter
     var urlParams = new URLSearchParams(window.location.search);
     var query = urlParams.get('q');
+    var categoryParam = urlParams.get('category');
+
+    if (categoryParam) {
+        currentCat = categoryParam;
+        // Update active chip
+        filterChips.forEach(function (c) {
+            if (c.getAttribute('data-cat') === currentCat) {
+                c.classList.add('active');
+            } else {
+                c.classList.remove('active');
+            }
+        });
+    }
+
     if (query) {
         searchInput.value = query;
+    }
+
+    if (query || categoryParam) {
         applyFilters();
     }
 


### PR DESCRIPTION
🎨 **Palette: URL Synchronization for Resources**

💡 **What:**
Added URL synchronization to the `resources.html` page. Now, when you search for a tool or filter by category, the URL updates in real-time (e.g., `resources.html?category=threat&q=virus`). Reloading the page or sharing the link restores the exact same view.

🎯 **Why:**
Users often want to bookmark specific resource categories (like "Threat Intel") or share a search result with colleagues. Previously, the URL remained static, making this impossible. This change brings the "deep linking" experience found in modern web apps to this static site, consistent with the existing behavior on `tools.html`.

📸 **Verification:**
Verified that:
- Clicking a filter updates the `category` URL parameter.
- Typing in the search box updates the `q` URL parameter.
- Loading a URL with parameters (e.g., `?category=learning`) correctly activates the "Learning & CTFs" filter chip and filters the list.
- Deep linking works for both search terms and categories simultaneously.

♿ **Accessibility:**
- Leveraged existing accessible UI components.
- No changes to DOM structure that would affect screen readers, other than state updates which are standard.

---
*PR created automatically by Jules for task [981154014960277167](https://jules.google.com/task/981154014960277167) started by @PietjePuh*