### PR TITLE
🔒 Add CODEOWNERS, dependabot.yml, update SECURITY.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owner
+* @PietjePuh

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "auto-merge"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ We currently support the following versions with security updates:
 
 If you discover a security vulnerability within this project, please report it via one of the following methods:
 
-1.  **Email:** [Add your security email here or use a secure contact method]
+1.  **Email:** timvanmaurik7@gmail.com
 2.  **GitHub Private Reporting:** Use the "Report a vulnerability" button in the Security tab of this repository.
 
 Please include the following in your report:
@@ -29,4 +29,4 @@ We will acknowledge receipt of your report within 48 hours and provide a timelin
 
 - **No PII:** Never commit Personally Identifiable Information (PII) or real-world credentials.
 - **Sanitize Links:** Ensure all external links point to official, verified security resources.
-- **Zero Trust:** Adhere to the "Assume Breach" mentality—don't trust inputs even if they originate from within the repo.
+- **Zero Trust:** Adhere to the "Assume Breach" mentality — don't trust inputs even if they originate from within the repo.


### PR DESCRIPTION
Adds GitHub governance files:
- `.github/CODEOWNERS` — sets @PietjePuh as default owner
- `.github/dependabot.yml` — weekly GitHub Actions dependency updates
- `SECURITY.md` — updated with actual contact email

Fixes #41